### PR TITLE
Register transmitter general interrupt fix

### DIFF
--- a/si570-register-transmitter.cc
+++ b/si570-register-transmitter.cc
@@ -19,8 +19,6 @@ Si570RegisterTransmitter::Si570RegisterTransmitter(
 
 TransmitState Si570RegisterTransmitter::transmit_state_ = kTransmitRegister;
 
-bool Si570RegisterTransmitter::busy_ = false;
-
 unsigned char Si570RegisterTransmitter::transmit_register_ = 0x00;
 unsigned char Si570RegisterTransmitter::transmit_value_ = 0x00;
 
@@ -28,7 +26,6 @@ void Si570RegisterTransmitter::TransmitRegister(unsigned char register_address,
     unsigned char value) {
   // Ensure last transmission's stop condition was sent.
   while (UCB0CTL1 & UCTXSTP);
-  Si570RegisterTransmitter::busy_ = true;
 
   transmit_register_ = register_address;
   transmit_value_ = value;
@@ -38,41 +35,15 @@ void Si570RegisterTransmitter::TransmitRegister(unsigned char register_address,
   // Send a start condition.
   UCB0CTL1 |= UCTR + UCTXSTT;
   __bis_SR_register(CPUOFF + GIE);
-  // Wait for start condition to be sent and TX interrupt to be triggered.
-  //while (!(this->tx_ie_flag_));
-  //this->tx_ie_flag_ = false;
 
-  // Send 'register_address'.
-  //UCB0TXBUF = register_address;
-
-  // Wait for 'register_address' to be sent.
-  //while (!(this->tx_ie_flag_));
-  //this->tx_ie_flag_ = false;
-
-  // Send 'value'.
-  //UCB0TXBUF = value;
-
-  // Wait for 'value' to be sent.
-  //while (!(this->tx_ie_flag_));
-  //this->tx_ie_flag_ = false;
-
-  // Send stop condition.
-  //UCB0CTL1 |= UCTXSTP;
-
-  // Clear the interrupt flag.
-  //IFG2 &= ~UCB0TXIFG;
-
-  //while(Si570RegisterTransmitter::busy_);
+  // Function will not reach this point until after the stop condition has
+  // begun sending (i.e., once the CPUOFF bit is cleared in the interrupt after
+  // the kTransmitStop state returns true.
 
   return;
 }
 
-TransmitState buffer[5];
-int buffer_index = 0;
-
 bool Si570RegisterTransmitter::TxIsr() {
-  buffer[buffer_index] = transmit_state_;
-  buffer_index++;
   switch(Si570RegisterTransmitter::transmit_state_) {
     case kTransmitRegister: {
       // Send 'register_address'.

--- a/si570-register-transmitter.h
+++ b/si570-register-transmitter.h
@@ -1,6 +1,13 @@
 #ifndef SI570_REGISTER_TRANSMITTER_H_
 #define SI570_REGISTER_TRANSMITTER_H_
 
+// Describes what will occur during the next TxIsr() call.
+enum TransmitState {
+  kTransmitRegister,
+  kTransmitValue,
+  kTransmitStop,
+};
+
 class Si570RegisterTransmitter {
   public:
     // Initializes the transmitter to transmit to 'slave_address'.
@@ -8,6 +15,21 @@ class Si570RegisterTransmitter {
 
     // Writes 'value' to the SI570 register at 'register_address'.
     void TransmitRegister(unsigned char register_address, unsigned char value);
+
+    static bool TxIsr();
+
+  private:
+    // The state of the transmit state machine.
+    static TransmitState transmit_state_;
+
+    // The register to be transmitted.
+    static unsigned char transmit_register_;
+
+    // The value to be transmitted
+    static unsigned char transmit_value_;
+
+    // Whether the transmitter is currently transmitting.
+    static bool busy_;
 };
 
 #endif /* SI570_REGISTER_TRANSMITTER_H_ */

--- a/si570-register-transmitter.h
+++ b/si570-register-transmitter.h
@@ -27,9 +27,6 @@ class Si570RegisterTransmitter {
 
     // The value to be transmitted
     static unsigned char transmit_value_;
-
-    // Whether the transmitter is currently transmitting.
-    static bool busy_;
 };
 
 #endif /* SI570_REGISTER_TRANSMITTER_H_ */

--- a/tests/si570-register-transmitter_test-driver.cc
+++ b/tests/si570-register-transmitter_test-driver.cc
@@ -9,6 +9,8 @@ void main(void) {
   DCOCTL = CALDCO_16MHZ;     // Set DCO.
   BCSCTL1 = CALBC1_16MHZ;
   Si570RegisterTransmitter transmitter(0x48);
+
+  __bis_SR_register(GIE);
   transmitter.TransmitRegister(0x07, 'a');
   transmitter.TransmitRegister(0x08, 'b');
   transmitter.TransmitRegister(0x09, 'c');
@@ -16,4 +18,11 @@ void main(void) {
   transmitter.TransmitRegister(0x0b, 'e');
   transmitter.TransmitRegister(0x0c, 'f');
 
+}
+
+#pragma vector = USCIAB0TX_VECTOR
+__interrupt void USCIAB0TX_ISR() {
+  if (Si570RegisterTransmitter::TxIsr()) {
+    __bic_SR_register_on_exit(CPUOFF);
+  }
 }


### PR DESCRIPTION
Fixed bug with the register transmitter once general interrupts are enabled by changing the transmitter to use interrupts, rather than waiting for the interrupt flag in a while loop.